### PR TITLE
Make docker_http_.py compatible with Azure Container Registry

### DIFF
--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -301,12 +301,13 @@ class Transport(object):
                                   (resp.status, content))
 
     wrapper_object = json.loads(content)
-    _CheckState('token' in wrapper_object,
+    token = wrapper_object.get('token') or wrapper_object.get('access_token')
+    _CheckState(token is not None,
                 'Malformed JSON response: %s' % content)
 
     with self._lock:
       # We have successfully reauthenticated.
-      self._creds = v2_2_creds.Bearer(wrapper_object['token'])
+      self._creds = v2_2_creds.Bearer(token)
 
   # pylint: disable=invalid-name
   def Request(


### PR DESCRIPTION
Azure Container Registry returns "access_token" instead of "token" when the docker http client tries to authenticate. This change allows the docker_http_.py accept "access_token" as well.

Code change is from this PR:
https://github.com/google/containerregistry/commit/5d90e9983dea40bbdcc7e1145f94264e07f80600
Which has already been merged to google/containerregistry.
See https://github.com/bazelbuild/rules_k8s/issues/128 for discussions.
