### PR TITLE
Remove 2GiB upload restriction for docker_push

### DIFF
--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -335,7 +335,8 @@ class Transport(object):
               method = None,
               body = None,
               content_type = None,
-              accepted_mimes = None
+              accepted_mimes = None,
+              additional_headers = {}
              ):
     """Wrapper containing much of the boilerplate REST logic for Registry calls.
 
@@ -347,7 +348,8 @@ class Transport(object):
       body: the body to pass into the PUT request (or None for GET)
       content_type: the mime-type of the request (or None for JSON).
               content_type is ignored when body is None.
-      accepted_mimes: the list of acceptable mime-types
+      accepted_mimes: the list of acceptable mime-types.
+      additional_headers: additional headers to include in the request.
 
     Raises:
       BadStateException: an unexpected internal state has been encountered.
@@ -381,6 +383,8 @@ class Transport(object):
       # POST/PUT require a content-length, when no body is supplied.
       if method in ('POST', 'PUT') and not body:
         headers['content-length'] = '0'
+
+      headers.update(additional_headers)
 
       resp, content = self._transport.request(
           url, method, body=body, headers=headers)

--- a/client/v2_2/docker_image_.py
+++ b/client/v2_2/docker_image_.py
@@ -406,6 +406,18 @@ def is_compressed(name):
   return name[0:2] == b'\x1f\x8b'
 
 
+# Python earlier than 3.7 has a gzip.GzipFile bug that does not support writing
+# content longer than 2^31 bytes. To work around this, we write the content in
+# smaller chunks if exceed size limit.
+def _write_large_content_to_zipped_file(zipped, content, chunk_size=2**31-1):
+  if len(content) > chunk_size:
+    # Write the content in chunks
+    for i in range(0, len(content), chunk_size):
+      zipped.write(content[i:i+chunk_size])
+  else:
+    zipped.write(content)
+
+
 class FromTarball(DockerImage):
   """This decodes the image tarball output of docker_build for upload."""
 
@@ -458,7 +470,7 @@ class FromTarball(DockerImage):
         zipped = gzip.GzipFile(
             mode='wb', compresslevel=self._compresslevel, fileobj=buf)
         try:
-          zipped.write(content)
+          _write_large_content_to_zipped_file(zipped, content)
         finally:
           zipped.close()
         content = buf.getvalue()

--- a/client/v2_2/docker_session_.py
+++ b/client/v2_2/docker_session_.py
@@ -32,6 +32,14 @@ import six.moves.http_client
 import six.moves.urllib.parse
 
 
+# Theoretically max is INT_MAX but we need some extra space for headers.
+UPLOAD_CHUNK_MAX_SIZE = 2000000000
+
+
+def _exceed_max_chunk_size(image_body):
+  return len(image_body) > UPLOAD_CHUNK_MAX_SIZE
+
+
 def _tag_or_digest(name):
   if isinstance(name, docker_name.Tag):
     return name.tag
@@ -150,10 +158,62 @@ class Push(object):
         method='PUT',
         body=self._get_blob(image, digest),
         accepted_codes=[six.moves.http_client.CREATED])
+    
+  # pylint: disable=missing-docstring
+  def _patch_chunked_upload_image_body(self, image_body, digest):
+    if len(image_body) == 0:
+      raise ValueError('Empty image body')
+    
+    # See https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-a-blob-in-chunks
+
+    mounted, location = self._start_upload(digest, self._mount)
+
+    if mounted:
+      logging.info('Layer %s mounted.', digest)
+      return
+
+    location = self._get_absolute_url(location)
+
+    # Upload the content in chunks. Invoked at least once to get the response.
+    for i in range(0, len(image_body), UPLOAD_CHUNK_MAX_SIZE):
+      chunk = image_body[i:i + UPLOAD_CHUNK_MAX_SIZE]
+      chunk_start, chunk_end_inclusive = i, i + len(chunk) - 1
+      logging.info('Uploading chunk range %d-%d', chunk_start, chunk_end_inclusive)
+
+      resp, unused_content = self._transport.Request(
+          location,
+          method='PATCH',
+          body=chunk,
+          content_type='application/octet-stream',
+          additional_headers={
+              'Content-Range': '{start}-{end}'.format(start=chunk_start, end=chunk_end_inclusive)
+          },
+          accepted_codes=[
+              six.moves.http_client.NO_CONTENT, six.moves.http_client.ACCEPTED,
+              six.moves.http_client.CREATED
+          ])
+      # Need to use the new location in the response.
+      location = self._get_absolute_url(resp.get('location'))
+
+    location = self._add_digest(resp['location'], digest)
+    location = self._get_absolute_url(location)
+    self._transport.Request(
+        location,
+        method='PUT',
+        body=None,
+        accepted_codes=[six.moves.http_client.CREATED])
 
   # pylint: disable=missing-docstring
   def _patch_upload(self, image,
                     digest):
+    image_body = self._get_blob(image, digest)
+    # When the layer is too large, registry might reject.
+    # In this case, we need to do chunk upload.
+    if _exceed_max_chunk_size(image_body):
+      logging.info('Uploading layer %s in chunks.', digest)
+      self._patch_chunked_upload_image_body(image_body, digest)
+      return
+
     mounted, location = self._start_upload(digest, self._mount)
 
     if mounted:
@@ -165,7 +225,7 @@ class Push(object):
     resp, unused_content = self._transport.Request(
         location,
         method='PATCH',
-        body=self._get_blob(image, digest),
+        body=image_body,
         content_type='application/octet-stream',
         accepted_codes=[
             six.moves.http_client.NO_CONTENT, six.moves.http_client.ACCEPTED,
@@ -199,6 +259,14 @@ class Push(object):
     #   POST   /v2/<name>/blobs/uploads/        (no body*)
     #   PATCH  /v2/<name>/blobs/uploads/<uuid>  (full body)
     #   PUT    /v2/<name>/blobs/uploads/<uuid>  (no body)
+    # self._patch_upload(image, digest)
+    #
+    # When the layer is too large (> INT_MAX), we need to do chunk upload.
+    #   POST   /v2/<name>/blobs/uploads/        (no body*)
+    #   PATCH  /v2/<name>/blobs/uploads/<uuid>  (body chunk 1)
+    #   PATCH  /v2/<name>/blobs/uploads/<uuid>  (body chunk ...)
+    #   PUT    /v2/<name>/blobs/uploads/<uuid>  (no body)
+    # self._patch_chunked_upload_image_body(image_body, digest)
     #
     # * We attempt to perform a cross-repo mount if any repositories are
     # specified in the "mount" parameter. This does a fast copy from a


### PR DESCRIPTION
Changes made are:
1. Separate `zipped.write(...)` into smaller chunks. Before Python 3.6, it can only support at maximum INT_MAX single writes. However during my testing my local Python version can already handle larger writes, but included just in case.
2. Make patch load of layers into separate chunks.
  * httplib2 (used under the hood) will complain if request size exceeds INT_MAX. Some registries might also not be happy with a single huge request.
  * Instead, follow the [spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#pushing-a-blob-in-chunks) and upload in chunks smaller than the limit

How to test locally:
1. Copy the commit hash into universe WORKSPACE file: https://github.com/databricks/universe/pull/522676
2. Find an image that is forced to divide into multiple layers ([examples](https://src.dev.databricks.com/search?q=context%3Aglobal+2GB+and+docker_layer&patternType=standard&sm=0&groupBy=repo)). __DO NOT USE search-liveupdater to test image upload__, since this is the one I used for testing so the layer might have already been pushed
3. Merge `docker_layers` into a single one, and try running `bazel run <layer_name>_push` and `bazel run <layer_name>_push_harbor` etc.
4. Test that the image is good by running `docker run -it --rm <uploaded_image_with_sha>`. Might be better to talk with the team and ask them to verify it looks good.