### PR TITLE
IdentityToken support for docker http transport lib

### DIFF
--- a/client/docker_creds_.py
+++ b/client/docker_creds_.py
@@ -92,6 +92,29 @@ class Basic(SchemeProvider):
     p = self.password.encode('utf8')
     return base64.b64encode(u + b':' + p).decode('utf8')
 
+class IdentityToken(SchemeProvider):
+  """Implementation for providing ID token credentials."""
+
+  def __init__(self, token):
+    super(IdentityToken, self).__init__('Basic')
+    self._password = token 
+
+  @property
+  def username(self):
+    # MSFT for some reason requires the user name to be set to this value when using an identity token
+    # https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication?tabs=azure-cli
+    return '00000000-0000-0000-0000-000000000000' 
+
+  @property
+  def password(self):
+    return self._password
+
+  @property
+  def suffix(self):
+    u = self.username.encode('utf8')
+    p = self.password.encode('utf8')
+    return base64.b64encode(u + b':' + p).decode('utf8')
+
 
 _USERNAME = '_token'
 
@@ -278,14 +301,16 @@ class _DefaultKeychain(Keychain):
     for form in _FORMATS:
       if form % name.registry in auths:
         entry = auths[form % name.registry]
-        if 'auth' in entry:
+        if 'identitytoken' in entry:
+          token = entry['identitytoken']
+          return IdentityToken(token)
+        elif 'auth' in entry:
           decoded = base64.b64decode(entry['auth']).decode('utf8')
           username, password = decoded.split(':', 1)
           return Basic(username, password)
         elif 'username' in entry and 'password' in entry:
           return Basic(entry['username'], entry['password'])
         else:
-          # TODO(user): Support identitytoken
           # TODO(user): Support registrytoken
           raise Exception(
               'Unsupported entry in "auth" section of Docker config: ' +

--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -224,6 +224,9 @@ class Transport(object):
         'content-type': 'application/json',
         'user-agent': docker_name.USER_AGENT,
     }
+    url = '{scheme}://{registry}/v2/'.format(
+            scheme=Scheme(self._name.registry), registry=self._name.registry),
+          
     resp, content = self._transport.request(
         '{scheme}://{registry}/v2/'.format(
             scheme=Scheme(self._name.registry), registry=self._name.registry),

--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -224,9 +224,6 @@ class Transport(object):
         'content-type': 'application/json',
         'user-agent': docker_name.USER_AGENT,
     }
-    url = '{scheme}://{registry}/v2/'.format(
-            scheme=Scheme(self._name.registry), registry=self._name.registry),
-          
     resp, content = self._transport.request(
         '{scheme}://{registry}/v2/'.format(
             scheme=Scheme(self._name.registry), registry=self._name.registry),


### PR DESCRIPTION
IdentityToken auth is required now with the MSFT push to remove long lived Azure secrets.

Access has been replaced with SNI (Service Name Indication) where we are given a temporary credential from the Databricks HCVault secrets engine that we use to authorize with the Azure CLI.

```
 eng-tools/bin/hcvault get -c prod /v1/services/release-automation/service-principal/acr-push-sni -k client_pem > snicert.pem

az login --service-principal -u '86136764-3f68-4e03-893c-5234283bb498' -p snicert.pem --tenant '72f988bf-86f1-41af-91ab-2d7cd011db    47' --use-cert-sn-issuer

az acr login --name dbacrprodwestus.azurecr.io
```

The final call to `az acr login` will populate the ~/.docker/config.json with an identitytoken that is similar to a JWT.
This auth configuration is not supported by the containerregistry HTTP transport interface so we add support for it.

## Testing
```
Logging in to Docker:
+ az acr login --name dbacrprodwestus.azurecr.io
The login server endpoint suffix '.azurecr.io' is automatically omitted.
Login Succeeded
+ echo 'Pushing service mini bundle to the ACR:'
Pushing service mini bundle to the ACR:
+ ./bazel-bin/deployment/artifact/push_bundle --service-bundle service_manifest_test.json --dest-docker-host=dbacrprodwestus.azurecr.io

DEBUG: making normal request to registry with headers:  {'user-agent': '//containerregistry/client:push_bundle_deploy.pex', 'Authorization': 'Bearer eyJhbGciOiJ******'}

Pushed multiplatform image to: dbacrprodwestus.azurecr.io/universe/release-test-service:release-test-service_2024-07-02_19.53.29Z_master_295a70ae_1723446216
Digest: sha256:67030dacea8716c89ee1b5bf6bec39f15f922b55a2e26068536f85082cae152c
```