### PR TITLE
Set chunk size to 2GB

### DIFF
--- a/client/v2_2/docker_session_.py
+++ b/client/v2_2/docker_session_.py
@@ -32,8 +32,10 @@ import six.moves.http_client
 import six.moves.urllib.parse
 
 
-# 200 MB chunk to balance performance in poor networking conditions
-UPLOAD_CHUNK_MAX_SIZE = int(2e8)
+# 200 MB chunk balances performance in poor networking conditions
+# However we need to use 2GB for now for CMv2 to avoid hitting the partial upload api
+# GCR registry unexpectedly drops partial upload connections (us-central1-docker.pkg.dev)
+UPLOAD_CHUNK_MAX_SIZE = int(2e9)
 
 
 def _exceed_max_chunk_size(image_body):


### PR DESCRIPTION
```
Target //compute-fabric/dbr-utils/images:dbr-utils_push_gcr up-to-date:
  bazel-bin/compute-fabric/dbr-utils/images/dbr-utils_push_gcr
(23:20:02) INFO: Elapsed time: 11.472s, Critical Path: 5.41s
(23:20:02) INFO: 5 processes: 1 internal, 4 linux-sandbox.
(23:20:02) INFO: Build Event Protocol files produced successfully.
(23:20:02) INFO: Build completed successfully, 5 total actions
I0328 23:20:02.586409  228882 fast_pusher_.py:147] Reading config from '/home/ruvan.jayaweera/universe/bazel-bin/compute-fabric/dbr-utils/images/dbr-utils_push_gcr.runfiles/universe/compute-fabric/dbr-utils/images/dbr-utils.config'
I0328 23:20:02.586620  228882 fast_pusher_.py:196] Loading v2.2 image from disk ...
I0328 23:20:02.586902  228882 docker_creds_.py:276] Loading Docker credentials for repository 'us-central1-docker.pkg.dev/databricks-dev-artifacts/universe/dbr-utils:test-ruvan'
I0328 23:20:02.931924  228882 fast_pusher_.py:214] Starting upload ...
I0328 23:20:03.204503  228882 docker_session_.py:349] Layer sha256:5cf4321f801a32ee75f06b34f3bda04fc425a2c56d44df3bd432f18f59b66276 exists, skipping
I0328 23:20:03.206461  228882 docker_session_.py:349] Layer sha256:bc0cc021b4b4deae569870c104c5e9d8f2c3e27cb7c497776de8eb98a94b3396 exists, skipping
I0328 23:20:03.342870  228882 docker_session_.py:349] Layer sha256:4bc1577e52579aa5a6807f94a22ac1322a2c2cc14c22e45fcd2a9aa33ad1a058 exists, skipping
I0328 23:20:03.346343  228882 docker_session_.py:349] Layer sha256:79ca4f20e0c4742b9109f5009def8c073d082c0c765fc816eb9c922e8f05b664 exists, skipping
I0328 23:20:03.346822  228882 docker_session_.py:349] Layer sha256:86e5016c269355b382c9cabab4f6646d56d75914f20d545289970436dae431b1 exists, skipping
I0328 23:20:03.351722  228882 docker_session_.py:349] Layer sha256:36ab8fd631f7bc4614e64a1c92b895c6c6d14fc204a9841511452bb57b859b11 exists, skipping
I0328 23:20:03.354564  228882 docker_session_.py:349] Layer sha256:13af6952ffe8e8863e21b59032fe3c0ecd16e280a5a6f086c6ed40f5f7df6ec7 exists, skipping
I0328 23:20:03.355293  228882 docker_session_.py:349] Layer sha256:e56877e1fe36d0432e8ba4ae128184492d2eeef58a9d187c51c38fd18cdf4eb1 exists, skipping
I0328 23:20:03.462733  228882 docker_session_.py:349] Layer sha256:2d17f61a2647efea5402f0be84c657ae6a538e1bc686ad4d9b0b2b0aa8dc55ed exists, skipping
I0328 23:20:03.474988  228882 docker_session_.py:349] Layer sha256:90944dacf197aa8180d951adaaca9bb90e7877bdfc8c3f31edc2e4e27e52f290 exists, skipping
I0328 23:20:03.479397  228882 docker_session_.py:349] Layer sha256:48c1363d21652b4bb5cf647bb1de5f2bdf8479ce26555d04fe281d7a7dfd38df exists, skipping
I0328 23:20:03.619808  228882 docker_session_.py:349] Layer sha256:b0226e52bdd95efb5a3bca224cf827f439e0431198c5fa504293f99de1666ede exists, skipping
I0328 23:20:03.630879  228882 docker_session_.py:349] Layer sha256:7d697934977e7172121b2b2c27d7aad46602b8008e46acb6157fb0cf82501d7f exists, skipping
I0328 23:20:03.654498  228882 docker_session_.py:349] Layer sha256:d865f4f5bb880f5d97e97b0a555f36ebfd148b3e5accf4ad00134d176017c241 exists, skipping
I0328 23:20:16.124150  228882 docker_session_.py:353] Layer sha256:7530a7c28888e0f0ac286a61aba27d7a51914371d9ce408e1b07a9c18377083f pushed.
us-central1-docker.pkg.dev/databricks-dev-artifacts/universe/dbr-utils:test-ruvan was published with digest: sha256:29a90c3075cd8e6b7cb7b5dec2d24ef6cd92e897d448f6d1fa23eb2210206c5a
I0328 23:20:16.984003  228882 docker_session_.py:403] Finished upload of: us-central1-docker.pkg.dev/databricks-dev-artifacts/universe/dbr-utils:test-ruvan
```