### PR TITLE
Add additional headers to check API call

### DIFF
--- a/client/v1/docker_http_.py
+++ b/client/v1/docker_http_.py
@@ -52,7 +52,8 @@ def Request(transport,
             credentials,
             accepted_codes = None,
             body = None,
-            content_type = None):
+            content_type = None,
+            extra_headers = None):
   """Wrapper containing much of the boilerplate REST logic for Registry calls.
 
   Args:
@@ -62,6 +63,7 @@ def Request(transport,
     accepted_codes: the list of acceptable http status codes
     body: the body to pass into the PUT request (or None for GET)
     content_type: the mime-type of the request (or None for JSON)
+    extra_headers: optional dictionary of additional headers to include
 
   Raises:
     BadStatusException: the status codes wasn't among the acceptable set.
@@ -75,6 +77,8 @@ def Request(transport,
       'X-Docker-Token': 'true',
       'user-agent': docker_name.USER_AGENT,
   }
+  if extra_headers:
+    headers.update(extra_headers)
   resp, content = transport.request(
       url, 'PUT' if body else 'GET', body=body, headers=headers)
 

--- a/client/v2/docker_http_.py
+++ b/client/v2/docker_http_.py
@@ -306,7 +306,8 @@ class Transport(object):
       accepted_codes = None,
       method = None,
       body = None,
-      content_type = None):
+      content_type = None,
+      extra_headers = None):
     """Wrapper containing much of the boilerplate REST logic for Registry calls.
 
     Args:
@@ -317,6 +318,7 @@ class Transport(object):
       body: the body to pass into the PUT request (or None for GET)
       content_type: the mime-type of the request (or None for JSON).
               content_type is ignored when body is None.
+      extra_headers: optional dictionary of additional headers to include
 
     Raises:
       BadStateException: an unexpected internal state has been encountered.
@@ -347,6 +349,9 @@ class Transport(object):
       # POST/PUT require a content-length, when no body is supplied.
       if method in ('POST', 'PUT') and not body:
         headers['content-length'] = '0'
+
+      if extra_headers:
+        headers.update(extra_headers)
 
       resp, content = self._transport.request(
           url, method, body=body, headers=headers)

--- a/client/v2/docker_session_.py
+++ b/client/v2/docker_session_.py
@@ -107,7 +107,8 @@ class Push(object):
         method='GET',
         accepted_codes=[
             six.moves.http_client.OK, six.moves.http_client.NOT_FOUND
-        ])
+        ],
+        extra_headers={'Databricks-Arf-Bypass-Redirect': 'true'})
 
     return resp.status == six.moves.http_client.OK  # pytype: disable=attribute-error
 

--- a/client/v2_2/docker_http_.py
+++ b/client/v2_2/docker_http_.py
@@ -335,7 +335,8 @@ class Transport(object):
               method = None,
               body = None,
               content_type = None,
-              accepted_mimes = None
+              accepted_mimes = None,
+              extra_headers = None
              ):
     """Wrapper containing much of the boilerplate REST logic for Registry calls.
 
@@ -348,6 +349,7 @@ class Transport(object):
       content_type: the mime-type of the request (or None for JSON).
               content_type is ignored when body is None.
       accepted_mimes: the list of acceptable mime-types
+      extra_headers: optional dictionary of additional headers to include
 
     Raises:
       BadStateException: an unexpected internal state has been encountered.
@@ -381,6 +383,9 @@ class Transport(object):
       # POST/PUT require a content-length, when no body is supplied.
       if method in ('POST', 'PUT') and not body:
         headers['content-length'] = '0'
+
+      if extra_headers:
+        headers.update(extra_headers)
 
       resp, content = self._transport.request(
           url, method, body=body, headers=headers)

--- a/client/v2_2/docker_session_.py
+++ b/client/v2_2/docker_session_.py
@@ -110,7 +110,8 @@ class Push(object):
         accepted_codes=[
             six.moves.http_client.OK, six.moves.http_client.NOT_FOUND
         ],
-        accepted_mimes=[image.media_type()])
+        accepted_mimes=[image.media_type()],
+        extra_headers={'Databricks-Arf-Bypass-Redirect': 'true'})
 
     return resp.status == six.moves.http_client.OK  # pytype: disable=attribute-error
 


### PR DESCRIPTION
Allow adding additional headers to requests. Use this feature to add a Bypass redirection header which is then used during push (image existence check) to force image existence locally rather than in an upstream region the request may be redirected to.